### PR TITLE
Update InsecureProtocols.json

### DIFF
--- a/Workbooks/InsecureProtocols.json
+++ b/Workbooks/InsecureProtocols.json
@@ -1,5 +1,5 @@
 {
-  "version": "Notebook/1.0",
+  "version": "Notebook/1.1",
   "items": [
     {
       "type": 1,
@@ -261,7 +261,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let scEvents = dynamic([5827, 5828, 5829, 5830, 5831]);\r\nlet legacyAuth = SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !contains \"Browser\" and ClientAppUsed !contains \"Mobile Apps and Desktop clients\"\r\n| summarize Count=count() by Protocol=\"AAD Legacy Auth\";\r\nSecurityEvent\r\n| parse EventData with * '\"TicketEncryptionType\">' TicketEncryptionType '<' *\r\n| union Event\r\n| where (EventID == 2889) or (EventID == 3000 and EventLog == 'Microsoft-Windows-SMBServer/Audit') or (EventID == 4624 and AuthenticationPackageName == 'NTLM' and LmPackageName == 'NTLM V1' and Account !contains 'ANONYMOUS LOGON') or ((EventID == 4624 or EventID == 4776) and Level == 8 and PackageName contains 'WDigest') or (EventID == 4768 or EventID == 4769) and Level == 8 and (TicketEncryptionType != \"0x12\" and TicketEncryptionType != \"0x11\") or ((EventLog =~ \"System\" and Source =~ \"NETLOGON\") and EventID in (scEvents))\r\n| summarize Count=count() by bin(TimeGenerated, {TimeRange:grain}), tostring(EventID)\r\n//| extend Protocol=replace(tostring(4776), 'WDigest', replace(tostring(4768), 'Kerberos weak cipher', replace(tostring(4769), 'Kerberos weak cipher', replace(tostring(2889), 'Insecure LDAP', replace(tostring(4624), 'NTLM v1', replace(tostring(3000), 'SMB v1', tostring(EventID)))))))\r\n| extend Protocol = case(EventID == 4776, \"WDigest\", EventID == 4768 or EventID == 4769, \"Weak Kerberos Cipher\", EventID == 2889, \"Insecure LDAP\", EventID == 4624, \"NTLM v1\", EventID == 3000, \"SMBv1\", EventID in (scEvents), \"Vulnerable Secure Channel\", \"Unknown\")\r\n| project Protocol, Count\r\n| union legacyAuth\r\n| sort by Count desc\r\n",
+              "query": "let scEvents = dynamic([5827, 5828, 5829, 5830, 5831]);\r\nlet legacyAuth = SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !in (\"Browser\", \"Mobile Apps and Desktop clients\", \"\")\r\n| summarize Count=count() by Protocol=\"AAD Legacy Auth\";\r\nSecurityEvent\r\n| parse EventData with * '\"TicketEncryptionType\">' TicketEncryptionType '<' *\r\n| union Event\r\n| where (EventID == 2889) or (EventID == 3000 and EventLog == 'Microsoft-Windows-SMBServer/Audit') or (EventID == 4624 and AuthenticationPackageName == 'NTLM' and LmPackageName == 'NTLM V1' and Account !contains 'ANONYMOUS LOGON') or ((EventID == 4624 or EventID == 4776) and Level == 8 and PackageName contains 'WDigest') or (EventID == 4768 or EventID == 4769) and Level == 8 and (TicketEncryptionType != \"0x12\" and TicketEncryptionType != \"0x11\") or ((EventLog =~ \"System\" and Source =~ \"NETLOGON\") and EventID in (scEvents))\r\n| summarize Count=count() by bin(TimeGenerated, {TimeRange:grain}), tostring(EventID)\r\n//| extend Protocol=replace(tostring(4776), 'WDigest', replace(tostring(4768), 'Kerberos weak cipher', replace(tostring(4769), 'Kerberos weak cipher', replace(tostring(2889), 'Insecure LDAP', replace(tostring(4624), 'NTLM v1', replace(tostring(3000), 'SMB v1', tostring(EventID)))))))\r\n| extend Protocol = case(EventID == 4776, \"WDigest\", EventID == 4768 or EventID == 4769, \"Weak Kerberos Cipher\", EventID == 2889, \"Insecure LDAP\", EventID == 4624, \"NTLM v1\", EventID == 3000, \"SMBv1\", EventID in (scEvents), \"Vulnerable Secure Channel\", \"Unknown\")\r\n| project Protocol, Count\r\n| union legacyAuth\r\n| sort by Count desc\r\n",
               "size": 0,
               "title": "Summary of Insecure Protocols: {TimeRange:label}",
               "timeContext": {
@@ -304,7 +304,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let scEvents = dynamic([5827, 5828, 5829, 5830, 5831]);\r\nlet legacyAuth = SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !contains \"Browser\" and ClientAppUsed !contains \"Mobile Apps and Desktop clients\"\r\n| summarize Count=count() by bin(TimeGenerated, {TimeRange:grain}), Protocol=\"AAD Legacy Auth\";\r\nSecurityEvent\r\n| parse EventData with * '\"TicketEncryptionType\">' TicketEncryptionType '<' *\r\n| union Event\r\n| where (EventID == 2889) or (EventID == 3000 and EventLog == 'Microsoft-Windows-SMBServer/Audit') or (EventID == 4624 and AuthenticationPackageName == 'NTLM' and LmPackageName == 'NTLM V1' and Account !contains 'ANONYMOUS LOGON') or ((EventID == 4624 or EventID == 4776) and Level == 8 and PackageName contains 'WDigest') or (EventID == 4768 or EventID == 4769) and Level == 8 and (TicketEncryptionType != \"0x12\" and TicketEncryptionType != \"0x11\") or ((EventLog =~ \"System\" and Source =~ \"NETLOGON\") and EventID in (scEvents))\r\n| summarize Count=count() by bin(TimeGenerated, {TimeRange:grain}), tostring(EventID)\r\n//| extend Protocol=replace(tostring(4776), 'WDigest', replace(tostring(4768), 'Kerberos weak cipher', replace(tostring(4769), 'Kerberos weak cipher', replace(tostring(2889), 'Insecure LDAP', replace(tostring(4624), 'NTLM v1', replace(tostring(3000), 'SMB v1', tostring(EventID)))))))\r\n| extend Protocol = case(EventID == 4776, \"WDigest\", EventID == 4768 or EventID == 4769, \"Weak Kerberos Cipher\", EventID == 2889, \"Insecure LDAP\", EventID == 4624, \"NTLM v1\", EventID == 3000, \"SMBv1\", EventID in (scEvents), \"Vulnerable Secure Channel\", \"Unknown\")\r\n| project Protocol, Count, TimeGenerated\r\n| union legacyAuth\r\n| where Protocol =~ \"{SelectedProtocol}\" or \"{SelectedProtocol}\" =~ \"All\"\r\n| sort by Count desc\r\n",
+              "query": "let scEvents = dynamic([5827, 5828, 5829, 5830, 5831]);\r\nlet legacyAuth = SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !in (\"Browser\", \"Mobile Apps and Desktop clients\", \"\")\r\n| summarize Count=count() by bin(TimeGenerated, {TimeRange:grain}), Protocol=\"AAD Legacy Auth\";\r\nSecurityEvent\r\n| parse EventData with * '\"TicketEncryptionType\">' TicketEncryptionType '<' *\r\n| union Event\r\n| where (EventID == 2889) or (EventID == 3000 and EventLog == 'Microsoft-Windows-SMBServer/Audit') or (EventID == 4624 and AuthenticationPackageName == 'NTLM' and LmPackageName == 'NTLM V1' and Account !contains 'ANONYMOUS LOGON') or ((EventID == 4624 or EventID == 4776) and Level == 8 and PackageName contains 'WDigest') or (EventID == 4768 or EventID == 4769) and Level == 8 and (TicketEncryptionType != \"0x12\" and TicketEncryptionType != \"0x11\") or ((EventLog =~ \"System\" and Source =~ \"NETLOGON\") and EventID in (scEvents))\r\n| summarize Count=count() by bin(TimeGenerated, {TimeRange:grain}), tostring(EventID)\r\n//| extend Protocol=replace(tostring(4776), 'WDigest', replace(tostring(4768), 'Kerberos weak cipher', replace(tostring(4769), 'Kerberos weak cipher', replace(tostring(2889), 'Insecure LDAP', replace(tostring(4624), 'NTLM v1', replace(tostring(3000), 'SMB v1', tostring(EventID)))))))\r\n| extend Protocol = case(EventID == 4776, \"WDigest\", EventID == 4768 or EventID == 4769, \"Weak Kerberos Cipher\", EventID == 2889, \"Insecure LDAP\", EventID == 4624, \"NTLM v1\", EventID == 3000, \"SMBv1\", EventID in (scEvents), \"Vulnerable Secure Channel\", \"Unknown\")\r\n| project Protocol, Count, TimeGenerated\r\n| union legacyAuth\r\n| where Protocol =~ \"{SelectedProtocol}\" or \"{SelectedProtocol}\" =~ \"All\"\r\n| sort by Count desc\r\n",
               "size": 0,
               "title": "Summary of Insecure Protocols: {TimeRange:label}",
               "timeContext": {
@@ -344,7 +344,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let scEvents = dynamic([5827, 5828, 5829, 5830, 5831]);\r\nlet legacyAuth = SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !contains \"Browser\" and ClientAppUsed !contains \"Mobile Apps and Desktop clients\"\r\n| summarize FirstOccurance=min(TimeGenerated), LastOccurance=max(TimeGenerated), Count=count() by Protocol=\"AAD Legacy Auth\";\r\nSecurityEvent\r\n| parse EventData with * '\"TicketEncryptionType\">' TicketEncryptionType '<' *\r\n| union Event\r\n| where (EventID == 2889) or (EventID == 3000 and EventLog == 'Microsoft-Windows-SMBServer/Audit') or (EventID == 4624 and AuthenticationPackageName == 'NTLM' and LmPackageName == 'NTLM V1' and Account !contains 'ANONYMOUS LOGON') or ((EventID == 4624 or EventID == 4776) and Level == 8 and PackageName contains 'WDigest') or (EventID == 4768 or EventID == 4769) and Level == 8 and (TicketEncryptionType != \"0x12\" and TicketEncryptionType != \"0x11\") or ((EventLog =~ \"System\" and Source =~ \"NETLOGON\") and EventID in (scEvents))\r\n| summarize FirstOccurance=min(TimeGenerated), LastOccurance=max(TimeGenerated), Count=count() by tostring(EventID)\r\n//| extend Protocol=replace(tostring(4776), 'WDigest', replace(tostring(4768), 'Kerberos weak cipher', replace(tostring(4769), 'Kerberos weak cipher', replace(tostring(2889), 'Insecure LDAP', replace(tostring(4624), 'NTLM v1', replace(tostring(3000), 'SMB v1', tostring(EventID)))))))\r\n| extend Protocol = case(EventID == 4776, \"WDigest\", EventID == 4768 or EventID == 4769, \"Weak Kerberos Cipher\", EventID == 2889, \"Insecure LDAP\", EventID == 4624, \"NTLM v1\", EventID == 3000, \"SMBv1\", EventID in (scEvents), \"Vulnerable Secure Channel\", \"Unknown\")\r\n| summarize FirstOccurance=min(FirstOccurance), LastOccurance=max(LastOccurance), Count=sum(Count) by Protocol\r\n| union legacyAuth\r\n| sort by Count desc\r\n",
+              "query": "let scEvents = dynamic([5827, 5828, 5829, 5830, 5831]);\r\nlet legacyAuth = SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !in (\"Browser\", \"Mobile Apps and Desktop clients\", \"\")\r\n| summarize FirstOccurance=min(TimeGenerated), LastOccurance=max(TimeGenerated), Count=count() by Protocol=\"AAD Legacy Auth\";\r\nSecurityEvent\r\n| parse EventData with * '\"TicketEncryptionType\">' TicketEncryptionType '<' *\r\n| union Event\r\n| where (EventID == 2889) or (EventID == 3000 and EventLog == 'Microsoft-Windows-SMBServer/Audit') or (EventID == 4624 and AuthenticationPackageName == 'NTLM' and LmPackageName == 'NTLM V1' and Account !contains 'ANONYMOUS LOGON') or ((EventID == 4624 or EventID == 4776) and Level == 8 and PackageName contains 'WDigest') or (EventID == 4768 or EventID == 4769) and Level == 8 and (TicketEncryptionType != \"0x12\" and TicketEncryptionType != \"0x11\") or ((EventLog =~ \"System\" and Source =~ \"NETLOGON\") and EventID in (scEvents))\r\n| summarize FirstOccurance=min(TimeGenerated), LastOccurance=max(TimeGenerated), Count=count() by tostring(EventID)\r\n//| extend Protocol=replace(tostring(4776), 'WDigest', replace(tostring(4768), 'Kerberos weak cipher', replace(tostring(4769), 'Kerberos weak cipher', replace(tostring(2889), 'Insecure LDAP', replace(tostring(4624), 'NTLM v1', replace(tostring(3000), 'SMB v1', tostring(EventID)))))))\r\n| extend Protocol = case(EventID == 4776, \"WDigest\", EventID == 4768 or EventID == 4769, \"Weak Kerberos Cipher\", EventID == 2889, \"Insecure LDAP\", EventID == 4624, \"NTLM v1\", EventID == 3000, \"SMBv1\", EventID in (scEvents), \"Vulnerable Secure Channel\", \"Unknown\")\r\n| summarize FirstOccurance=min(FirstOccurance), LastOccurance=max(LastOccurance), Count=sum(Count) by Protocol\r\n| union legacyAuth\r\n| sort by Count desc\r\n",
               "size": 1,
               "title": "Summary of Insecure Protocols found in: {TimeRange:label}",
               "timeContext": {
@@ -2102,7 +2102,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !contains \"Browser\" and ClientAppUsed !contains \"Mobile Apps and Desktop clients\"\r\n| summarize Count=count() by UserPrincipalName, ClientAppUsed //doughnut\r\n| order by Count desc",
+              "query": "SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !in (\"Browser\", \"Mobile Apps and Desktop clients\", \"\")\r\n| summarize Count=count() by UserPrincipalName, ClientAppUsed //doughnut\r\n| order by Count desc",
               "size": 0,
               "title": "Legacy authentications, by account",
               "timeContext": {
@@ -2146,7 +2146,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !contains \"Browser\" and ClientAppUsed !contains \"Mobile Apps and Desktop clients\"\r\n| summarize Count=count() by IPAddress,ClientAppUsed //doughnut\r\n| order by Count desc",
+              "query": "SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !in (\"Browser\", \"Mobile Apps and Desktop clients\", \"\")\r\n| summarize Count=count() by IPAddress,ClientAppUsed //doughnut\r\n| order by Count desc",
               "size": 0,
               "title": "Legacy authentications, by IP address",
               "timeContext": {
@@ -2186,7 +2186,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !contains \"Browser\" and ClientAppUsed !contains \"Mobile Apps and Desktop clients\"\r\n| summarize count() by UserPrincipalName, bin(TimeGenerated, {TimeRange:grain})\r\n| order by count_\r\n",
+              "query": "SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !in (\"Browser\", \"Mobile Apps and Desktop clients\", \"\")\r\n| summarize count() by UserPrincipalName, bin(TimeGenerated, {TimeRange:grain})\r\n| order by count_\r\n",
               "size": 1,
               "title": "Account events over time - select timebrush",
               "timeContext": {
@@ -2260,7 +2260,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "SigninLogs\r\n| where TimeGenerated between ({AADTimebrushAccount:start}..({AADTimebrushAccount:end}+{AADTimebrushAccount:grain}))\r\n| where ResultType == 0\r\n| where ClientAppUsed !contains \"Browser\" and ClientAppUsed !contains \"Mobile Apps and Desktop clients\"\r\n| summarize Count=count() by UserPrincipalName, ClientAppUsed\r\n",
+              "query": "SigninLogs\r\n| where TimeGenerated between ({AADTimebrushAccount:start}..({AADTimebrushAccount:end}+{AADTimebrushAccount:grain}))\r\n| where ResultType == 0\r\n| where ClientAppUsed !in (\"Browser\", \"Mobile Apps and Desktop clients\", \"\")\r\n| summarize Count=count() by UserPrincipalName, ClientAppUsed\r\n",
               "size": 1,
               "title": "Account events over time ({AADTimebrushAccount:label})",
               "queryType": 0,
@@ -2292,7 +2292,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !contains \"Browser\" and ClientAppUsed !contains \"Mobile Apps and Desktop clients\"\r\n| summarize count() by IPAddress, bin(TimeGenerated, {TimeRange:grain})\r\n| order by count_\r\n",
+              "query": "SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !in (\"Browser\", \"Mobile Apps and Desktop clients\", \"\")\r\n| summarize count() by IPAddress, bin(TimeGenerated, {TimeRange:grain})\r\n| order by count_\r\n",
               "size": 1,
               "title": "IPAddresses over time - select timebrush",
               "timeContext": {
@@ -2366,7 +2366,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "SigninLogs\r\n| where TimeGenerated between ({AADTimebrushAccount:start}..({AADTimebrushAccount:end}+{AADTimebrushAccount:grain}))\r\n| where ResultType == 0\r\n| where ClientAppUsed !contains \"Browser\" and ClientAppUsed !contains \"Mobile Apps and Desktop clients\"\r\n| summarize Count=count() by IPAddress, ClientAppUsed\r\n| order by Count\r\n",
+              "query": "SigninLogs\r\n| where TimeGenerated between ({AADTimebrushAccount:start}..({AADTimebrushAccount:end}+{AADTimebrushAccount:grain}))\r\n| where ResultType == 0\r\n| where ClientAppUsed !in (\"Browser\", \"Mobile Apps and Desktop clients\", \"\")\r\n| summarize Count=count() by IPAddress, ClientAppUsed\r\n| order by Count\r\n",
               "size": 1,
               "title": "IP events over time ({AADTimebrushIPAddress:label})",
               "queryType": 0,
@@ -2410,7 +2410,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !contains \"Browser\" and ClientAppUsed !contains \"Mobile Apps and Desktop clients\"\r\n| summarize count() by ClientAppUsed, UserPrincipalName //bar",
+              "query": "SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !in (\"Browser\", \"Mobile Apps and Desktop clients\", \"\")\r\n| summarize count() by ClientAppUsed, UserPrincipalName //bar",
               "size": 0,
               "title": "Legacy authentications, by authentication type",
               "timeContext": {
@@ -2482,7 +2482,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !contains \"Browser\" and ClientAppUsed !contains \"Mobile Apps and Desktop clients\"\r\n| summarize count() by tostring(CountryOrRegion=LocationDetails.countryOrRegion), ClientAppUsed //bar\r\n| order by count_\r\n",
+              "query": "SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !in (\"Browser\", \"Mobile Apps and Desktop clients\", \"\")\r\n| summarize count() by tostring(CountryOrRegion=LocationDetails.countryOrRegion), ClientAppUsed //bar\r\n| order by count_\r\n",
               "size": 0,
               "title": "Legacy authentications, by country/region",
               "timeContext": {
@@ -2555,7 +2555,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !contains \"Browser\" and ClientAppUsed !contains \"Mobile Apps and Desktop clients\"\r\n| extend mergeCountry = toupper(LocationDetails.countryOrRegion)\r\n| summarize  IPaddress = make_set(IPAddress), Count=count() by UserPrincipalName,  ClientAppUsed, tostring(CountryOrRegion=mergeCountry) //table\r\n| order by Count desc",
+              "query": "SigninLogs\r\n| where ResultType == 0\r\n| where ClientAppUsed !in (\"Browser\", \"Mobile Apps and Desktop clients\", \"\")\r\n| extend mergeCountry = toupper(LocationDetails.countryOrRegion)\r\n| summarize  IPaddress = make_set(IPAddress), Count=count() by UserPrincipalName,  ClientAppUsed, tostring(CountryOrRegion=mergeCountry) //table\r\n| order by Count desc",
               "size": 0,
               "showAnalytics": true,
               "title": "Legacy authentications details",


### PR DESCRIPTION
Empty ClientAppUsed is not considered Legacy Auth

   Required items, please complete
   
   Change(s):
   - Changed KQL from
  ClientAppUsed !contains "Browser" and ClientAppUsed !contains "Mobile Apps and Desktop clients"
to
 ClientAppUsed !in ("Browser", "Mobile Apps and Desktop clients", "")

   Reason for Change(s):
   - Empty ClientAppUsed is not considered Legacy Auth

   Version Updated:
   - Yes

   Testing Completed:
   - No 

   Checked that the validations are passing and have addressed any issues that are present:
   - No




